### PR TITLE
Update grammar constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-sequence-languages",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-sequence-languages",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-sequence-languages",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Consolidated parsing for languages with first-party support in Aerie sequencing",
   "type": "module",
   "author": "NASA/JPL",

--- a/src/languages/satf/constants/satf-sasf-constants.ts
+++ b/src/languages/satf/constants/satf-sasf-constants.ts
@@ -140,4 +140,4 @@ export const SATF_SASF_NODES = {
   PARAM_DURATION,
   PARAM_QUOTED_STRING,
   PARAM_STRING,
-};
+} as const;

--- a/src/languages/seq-n/seqn-grammar-constants.ts
+++ b/src/languages/seq-n/seqn-grammar-constants.ts
@@ -11,6 +11,8 @@ export const SEQN_NODES = {
   GROUND_BLOCK: 'GroundBlock',
   GROUND_EVENT: 'GroundEvent',
   LOAD: 'Load',
+  EPOCH: 'Epoch',
+  ENGINE: 'Engine',
   REQUEST: 'Request',
   REPEAT_ARG: 'RepeatArg',
   ENUM: 'Enum',

--- a/src/languages/seq-n/seqn-grammar-constants.ts
+++ b/src/languages/seq-n/seqn-grammar-constants.ts
@@ -46,4 +46,10 @@ export const SEQN_NODES = {
   VAR_UINT: 'UINT',
   VAR_FLOAT: 'FLOAT',
   VAR_INT: 'INT',
+  TIME_TAG: 'TimeTag',
+  TIME_ABSOLUTE: 'TimeAbsolute',
+  TIME_EPOCH: 'TimeEpoch',
+  TIME_GROUND_EPOCH: 'TimeGroundEpoch',
+  TIME_RELATIVE: 'TimeRelative',
+  TIME_BLOCK_RELATIVE: 'TimeBlockRelative',
 } as const;

--- a/src/languages/seq-n/seqn-grammar-constants.ts
+++ b/src/languages/seq-n/seqn-grammar-constants.ts
@@ -20,6 +20,8 @@ export const SEQN_NODES = {
   OBJECT: 'Object',
   METADATA: 'Metadata',
   METADATA_ENTRY: 'MetaEntry',
+  MODELS: 'Models',
+  MODEL_ENTRY: 'Model',
   KEY: 'Key',
   VALUE: 'Value',
   ID_DECLARATION: 'IdDeclaration',
@@ -42,4 +44,4 @@ export const SEQN_NODES = {
   VAR_UINT: 'UINT',
   VAR_FLOAT: 'FLOAT',
   VAR_INT: 'INT',
-};
+} as const;

--- a/src/languages/seq-n/token.test.ts
+++ b/src/languages/seq-n/token.test.ts
@@ -187,7 +187,8 @@ describe('variables', () => {
     assertNoErrorNodes(input);
     const parseTree = SeqnParser.parse(input);
     const localNodes = parseTree.topNode.getChild(SEQN_NODES.LOCAL_DECLARATION)?.getChildren(SEQN_NODES.VARIABLE) ?? [];
-    const paramNodes = parseTree.topNode.getChild(SEQN_NODES.PARAMETER_DECLARATION)?.getChildren(SEQN_NODES.VARIABLE) ?? [];
+    const paramNodes =
+      parseTree.topNode.getChild(SEQN_NODES.PARAMETER_DECLARATION)?.getChildren(SEQN_NODES.VARIABLE) ?? [];
     const variableNodes = [...localNodes, ...paramNodes];
     assert.deepEqual(
       variableNodes?.map(node => getNodeText(node.getChild(SEQN_NODES.VARIABLE_NAME)!, input)),


### PR DESCRIPTION
Set grammar constants `as const` to type as string literals instead of `string`. Adds two SeqN grammar token/rule keys. Also ran the formatter.