### PR TITLE
Fix for handling undefined immediate type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-sequence-languages",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Consolidated parsing for languages with first-party support in Aerie sequencing",
   "type": "module",
   "author": "NASA/JPL",

--- a/src/converters/seqJsonToSeqn.test.ts
+++ b/src/converters/seqJsonToSeqn.test.ts
@@ -473,7 +473,6 @@ C FSW_CMD_2 10 "ENUM" # fsw cmd 2 description
           description: 'noop command, no arguments',
           metadata: { processor: 'VC1A' },
           stem: 'NOOP',
-          type: 'immediate_command',
         },
         {
           args: [

--- a/src/converters/seqJsonToSeqn.ts
+++ b/src/converters/seqJsonToSeqn.ts
@@ -210,6 +210,7 @@ export function seqJsonToSeqn(seqJson: SeqJson): string {
     sequence.push(`@IMMEDIATE\n`);
     for (const realTimeCommand of seqJson.immediate_commands) {
       switch (realTimeCommand.type) {
+        case undefined:
         case 'immediate_command': {
           // FSW Commands
           sequence.push(commandToString(realTimeCommand));
@@ -221,7 +222,7 @@ export function seqJsonToSeqn(seqJson: SeqJson): string {
           break;
         }
         default: {
-          throw new Error(`Invalid immediate command type ${realTimeCommand.type}`);
+          throw new Error(`Invalid immediate command type`);
         }
       }
     }


### PR DESCRIPTION
SeqJSON allows immediate commands to omit the `type` key on immediate commands, in which case they're treated as FSW commands. This fix handles the case correctly (and updates a test case to exercise it).