### PR TITLE
Use factories for extensions that use ViewPlugin and use PhoenixResou…

### DIFF
--- a/src/languages/seq-n/language.ts
+++ b/src/languages/seq-n/language.ts
@@ -1,5 +1,4 @@
 import { LanguageSupport } from '@codemirror/language';
-import { ViewPlugin } from "@codemirror/view";
 import { debounce } from 'lodash-es';
 import type { InputLanguage } from '../../interfaces/language.js';
 import type { PhoenixContext, PhoenixResources } from '../../interfaces/phoenix.js';
@@ -12,51 +11,62 @@ import { seqnLinter } from './seq-n-linter.js';
 import { seqnTooltip } from './seq-n-tooltip.js';
 import { SeqNCommandInfoMapper, seqnToLibrarySequence } from './seq-n-tree-utils.js';
 import { getSeqnLRLanguage } from './seq-n.js';
-import type { Extension, SelectionRange } from "@codemirror/state";
-import { Transaction, EditorSelection } from "@codemirror/state";
+import type { Extension, SelectionRange } from '@codemirror/state';
+import { Transaction, EditorSelection } from '@codemirror/state';
 
 const debouncedSeqNHighlightBlock = debounce(seqNHighlightBlock, 250);
 
-export const sanitizeSmartQuotes = (s: string) =>
-  s.replace(/[\u201C\u201D]/g, '"').replace(/[\u2018\u2019]/g, "'");
+export const sanitizeSmartQuotes = (s: string) => s.replace(/[\u201C\u201D]/g, '"').replace(/[\u2018\u2019]/g, "'");
 
-export const sanitizeTextExtension = ViewPlugin.fromClass(class {
+export function sanitizeTextExtension(resources: PhoenixResources) {
   // CodeMirror extension that sanitizes text when doc is opened or when text is pasted
   // replaces curly quotes with ASCII quotes
-  constructor(view: any) {
-    this.sanitizeDocument(view);
-  }
+  return resources.ViewPlugin.fromClass(
+    class {
+      constructor(view: any) {
+        this.sanitizeDocument(view);
+      }
 
-  update(update: any) {
-    if (!update.docChanged) return;
+      update(update: any) {
+        if (!update.docChanged) {
+          return;
+        }
 
-    const openedOrPasted = update.transactions.some(
-      (t: any) => t.annotation(Transaction.userEvent) === "file.open" || t.annotation(Transaction.userEvent) === "input.paste"
-    );
-    if (!openedOrPasted) return;
+        const openedOrPasted = update.transactions.some(
+          (t: any) =>
+            t.annotation(Transaction.userEvent) === 'file.open' ||
+            t.annotation(Transaction.userEvent) === 'input.paste',
+        );
+        if (!openedOrPasted) {
+          return;
+        }
 
-    this.sanitizeDocument(update.view);
-  }
+        this.sanitizeDocument(update.view);
+      }
 
-  sanitizeDocument(view: any) {
-    const text = view.state.doc.toString();
-    const clean = sanitizeSmartQuotes(text);
-    if (clean === text) return;
+      sanitizeDocument(view: any) {
+        const text = view.state.doc.toString();
+        const clean = sanitizeSmartQuotes(text);
+        if (clean === text) {
+          return;
+        }
 
-    setTimeout(() => {
-      const oldSel = view.state.selection;
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: clean },
-        annotations: [Transaction.userEvent.of("sanitize.smartQuotes")],
-        selection: EditorSelection.create(
-          oldSel.ranges.map((r: SelectionRange) => EditorSelection.range(r.from, r.to))
-        ),
-      });
-    }, 0);
+        setTimeout(() => {
+          const oldSel = view.state.selection;
+          view.dispatch({
+            changes: { from: 0, to: view.state.doc.length, insert: clean },
+            annotations: [Transaction.userEvent.of('sanitize.smartQuotes')],
+            selection: EditorSelection.create(
+              oldSel.ranges.map((r: SelectionRange) => EditorSelection.range(r.from, r.to)),
+            ),
+          });
+        }, 0);
 
-    console.warn(`sanitized doc, replaced curly quotes`);
-  }
-});
+        console.warn(`sanitized doc, replaced curly quotes`);
+      }
+    },
+  );
+}
 
 /**
  * Get keyed object for SeqN editor extensions to more easily replace/extend components.
@@ -66,7 +76,7 @@ export function getSeqnExtensions(
   context: PhoenixContext,
   globals?: GlobalVariable[],
   mapper?: SeqNCommandInfoMapper,
-): {[key: string]: Extension} {
+): { [key: string]: Extension } {
   globals = globals ?? [];
   mapper = mapper ?? new SeqNCommandInfoMapper();
   const seqnLRLanguage = getSeqnLRLanguage(resources);
@@ -80,7 +90,7 @@ export function getSeqnExtensions(
     tooltip: seqnTooltip(context.commandDictionary, resources, context, mapper),
     indent: resources.indentService.of(seqnAutoIndent()),
     highlight: [resources.EditorView.updateListener.of(debouncedSeqNHighlightBlock), seqNBlockHighlighter(resources)],
-    sanitize: sanitizeTextExtension
+    sanitize: sanitizeTextExtension(resources),
   };
 }
 

--- a/src/languages/vml/language.ts
+++ b/src/languages/vml/language.ts
@@ -31,7 +31,7 @@ const getEditorExtension = (context: PhoenixContext, resources: PhoenixResources
     ),
     vmlTooltip(context.commandDictionary, librarySequenceMap, resources),
     // indentService.of(adaptation.autoIndent()) // VML doesn't seem to have an indenter???
-    [resources.EditorView.updateListener.of(debouncedVmlHighlightBlock), vmlBlockHighlighter],
+    [resources.EditorView.updateListener.of(debouncedVmlHighlightBlock), vmlBlockHighlighter(resources)],
   ];
 };
 

--- a/src/languages/vml/vml.ts
+++ b/src/languages/vml/vml.ts
@@ -175,25 +175,27 @@ export function vmlHighlightBlock(viewUpdate: ViewUpdate): SyntaxNode[] {
   return matchedNodes;
 }
 
-export const vmlBlockHighlighter = ViewPlugin.fromClass(
-  class {
-    decorations: DecorationSet;
-    constructor() {
-      this.decorations = Decoration.none;
-    }
-    update(viewUpdate: ViewUpdate): DecorationSet | null {
-      if (viewUpdate.selectionSet || viewUpdate.docChanged || viewUpdate.viewportChanged) {
-        const blocks = vmlHighlightBlock(viewUpdate);
-        this.decorations = Decoration.set(
-          // codemirror requires marks to be in sorted order
-          blocks.sort((a, b) => a.from - b.from).map(block => blockMark.range(block.from, block.to)),
-        );
-        return this.decorations;
+export function vmlBlockHighlighter(resources: PhoenixResources) {
+  return resources.ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      constructor() {
+        this.decorations = Decoration.none;
       }
-      return null;
-    }
-  },
-  {
-    decorations: viewPluginSpecification => viewPluginSpecification.decorations,
-  },
-);
+      update(viewUpdate: ViewUpdate): DecorationSet | null {
+        if (viewUpdate.selectionSet || viewUpdate.docChanged || viewUpdate.viewportChanged) {
+          const blocks = vmlHighlightBlock(viewUpdate);
+          this.decorations = Decoration.set(
+            // codemirror requires marks to be in sorted order
+            blocks.sort((a, b) => a.from - b.from).map(block => blockMark.range(block.from, block.to)),
+          );
+          return this.decorations;
+        }
+        return null;
+      }
+    },
+    {
+      decorations: viewPluginSpecification => viewPluginSpecification.decorations,
+    },
+  );
+}


### PR DESCRIPTION
…rces to access it instead of direct import to follow library conventions.

If we don't do this:
* sequence adaptations will create the `sanitize` extension when the adaptation is loaded/run
* This extension calls the CodeMirror `ViewPlugin` which is DOM/browser-only
* Therefore, loading the adaptation in a node context (ie. an Action) will break and throw an error

This way, we only instantiate the CM extension when it is needed, ie. in the browser.