### PR TITLE
Remove async from SASF/SATF to conform to adaptation interface

### DIFF
--- a/src/converters/satf-sasf-utils.test.ts
+++ b/src/converters/satf-sasf-utils.test.ts
@@ -4,20 +4,20 @@ import { ParsedSatf, ParsedSeqn } from '../languages/satf/types/types.js';
 
 //-- SATF to Seqn Test---
 describe('satfToSeqn', () => {
-  it('should return empty header and sequences for empty SATF string', async () => {
+  it('should return empty header and sequences for empty SATF string', () => {
     const satf = '';
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toEqual({ metadata: '', sequences: [] });
   });
 
-  it('should return empty for invalid SATF string', async () => {
+  it('should return empty for invalid SATF string', () => {
     const satf = ' invalid satf string ';
 
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toEqual({ metadata: '', sequences: [] } as ParsedSeqn);
   });
 
-  it('should parse valid SATF string with header and sequences', async () => {
+  it('should parse valid SATF string with header and sequences', () => {
     const satf = `
       CCS3ZF0000100000001NJPL3KS0L015$$MARK$$;
       MISSION_NAME = TEST;
@@ -34,13 +34,13 @@ describe('satfToSeqn', () => {
       absolute(temp,\\temp\\)
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('metadata');
     expect(result).toHaveProperty('sequences');
     expect(result.sequences).toBeInstanceOf(Array);
   });
 
-  it('should return empty sequences for SATF string with missing sequences', async () => {
+  it('should return empty sequences for SATF string with missing sequences', () => {
     const satf = `
       CCS3ZF0000100000001NJPL3KS0L015$$MARK$$;
       MISSION_NAME = TEST;
@@ -56,23 +56,23 @@ describe('satfToSeqn', () => {
       $$EOH
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('metadata');
     expect(result.sequences).toEqual([]);
   });
 
-  it('should return empty header for SATF string with missing header', async () => {
+  it('should return empty header for SATF string with missing header', () => {
     const satf = `
       $$EOH
       absolute(temp,\\temp\\)
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.metadata).toEqual('');
   });
 
-  it('should return valid sequence with models', async () => {
+  it('should return valid sequence with models', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -87,7 +87,7 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].steps)
@@ -99,7 +99,7 @@ describe('satfToSeqn', () => {
 @MODEL "y" "abc" "00:00:00"`);
   });
 
-  it('should throw for invalid time tag', async () => {
+  it('should throw for invalid time tag', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -115,15 +115,15 @@ describe('satfToSeqn', () => {
       $$EOF
     `;
     try {
-      await satfToSeqn(satf);
+      satfToSeqn(satf);
     } catch (error) {
-      expect(error.message).toStrictEqual(
+      expect((error as Error).message).toStrictEqual(
         "Invalid Time Tag 'MARS_TIME' found in SATF/SASF. Aborting SATF/SASF -> Seqn conversion...",
       );
     }
   });
 
-  it('should throw for no time', async () => {
+  it('should throw for no time', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -139,13 +139,15 @@ describe('satfToSeqn', () => {
       $$EOF
     `;
     try {
-      await satfToSeqn(satf);
+      satfToSeqn(satf);
     } catch (error) {
-      expect(error.message).toStrictEqual('No time found in SATF/SASF. Aborting SATF/SASF -> Seqn conversion...');
+      expect((error as Error).message).toStrictEqual(
+        'No time found in SATF/SASF. Aborting SATF/SASF -> Seqn conversion...',
+      );
     }
   });
 
-  it('should return valid sequence and models times with 00:00:00 for durations', async () => {
+  it('should return valid sequence and models times with 00:00:00 for durations', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -160,7 +162,7 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].steps)
@@ -172,7 +174,7 @@ describe('satfToSeqn', () => {
 @MODEL "c" "abc" "00:00:00"`);
   });
 
-  it('should return valid sequence and models times with single duration spread across all models', async () => {
+  it('should return valid sequence and models times with single duration spread across all models', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -188,7 +190,7 @@ describe('satfToSeqn', () => {
       $$EOF
     `;
     try {
-      const result = await satfToSeqn(satf);
+      const result = satfToSeqn(satf);
       expect(result).toHaveProperty('sequences');
       expect(result.sequences[0].name).toStrictEqual('test');
       expect(result.sequences[0].steps)
@@ -203,7 +205,7 @@ describe('satfToSeqn', () => {
     }
   });
 
-  it('should return an error of mismatch modeling times', async () => {
+  it('should return an error of mismatch modeling times', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -219,19 +221,19 @@ describe('satfToSeqn', () => {
       $$EOF
     `;
     try {
-      await satfToSeqn(satf);
+      satfToSeqn(satf);
     } catch (error) {
-      expect(error.message).toStrictEqual('Mismatch of models to durations');
+      expect((error as Error).message).toStrictEqual('Mismatch of models to durations');
     }
   });
 
-  it('should return valid sequence and model times with one duration per variable with two variables', async () => {
+  it('should return valid sequence and model times with one duration per variable with two variables', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
           STEPS,
           command (
-            0, SCHEDULED_TIME, \\00:01:00\\, EPOCH, 
+            0, SCHEDULED_TIME, \\00:01:00\\, EPOCH,
             ASSUMED_MODEL_VALUES,\\a=1,GLOBAL::b=1.1,00:00:01,00:00:02\\,
             CMD (),
             PROCESSORS, "PRI", end),
@@ -239,7 +241,7 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].steps).toStrictEqual(`E00:01:00 CMD
@@ -247,13 +249,13 @@ describe('satfToSeqn', () => {
 @MODEL "GLOBAL::b" 1.1 "00:00:02"`);
   });
 
-  it('should return valid sequence and model times with one duration per variable with three variables', async () => {
+  it('should return valid sequence and model times with one duration per variable with three variables', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
           STEPS,
           command (
-            0, SCHEDULED_TIME, \\00:01:00\\, EPOCH, 
+            0, SCHEDULED_TIME, \\00:01:00\\, EPOCH,
             ASSUMED_MODEL_VALUES,\\a=1,GLOBAL::b=1.1,c="abc",00:00:01,00:00:02,00:00:03\\,
             CMD (),
             PROCESSORS, "PRI", end),
@@ -261,7 +263,7 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].steps).toStrictEqual(`E00:01:00 CMD
@@ -270,13 +272,13 @@ describe('satfToSeqn', () => {
 @MODEL "c" "abc" "00:00:03"`);
   });
 
-  it('should handle multiline comments', async () => {
+  it('should handle multiline comments', () => {
     const satf = `
     $$EOH
     ABSOLUTE_SEQUENCE(test,\\testv01\\,
         STEPS,
         command (
-          1, SCHEDULED_TIME, \\00:01:00\\, FROM_PREVIOUS_START, 
+          1, SCHEDULED_TIME, \\00:01:00\\, FROM_PREVIOUS_START,
           COMMENT,\\"hi  : bye",
                  "A   : pickup shoe",
                  "B: put on shoe",
@@ -287,7 +289,7 @@ describe('satfToSeqn', () => {
       )
     $$EOF
   `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].steps).toStrictEqual(
@@ -295,7 +297,7 @@ describe('satfToSeqn', () => {
     );
   });
 
-  it('should return multiple sequence with models', async () => {
+  it('should return multiple sequence with models', () => {
     const satf = `
       $$EOH
       ABSOLUTE_SEQUENCE(test,\\testv01\\,
@@ -328,7 +330,7 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences.length).toBe(2);
     expect(result.sequences[0].name).toStrictEqual('test');
@@ -353,7 +355,7 @@ describe('satfToSeqn', () => {
 @MODEL "y" "abc" "00:00:00"`);
   });
 
-  it('should use globals', async () => {
+  it('should use globals', () => {
     const sasf = `
       $$EOH
       RT_on_board_block(test,\\testv01\\,
@@ -366,13 +368,13 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(sasf);
+    const result = satfToSeqn(sasf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].steps).toStrictEqual(`R00:01:00 ECHO "GLOBAL::GlobalG" 10 "NOGLOBAL"`);
   });
 
-  it('Parameters', async () => {
+  it('Parameters', () => {
     const satf = `
       $$EOH
       RT_on_board_block(/start.txt,\\start\\,
@@ -438,7 +440,7 @@ describe('satfToSeqn', () => {
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('start.txt');
     expect(result.sequences[0].inputParameters).toStrictEqual(`@INPUT_PARAMS_BEGIN
@@ -459,7 +461,7 @@ true UINT
     expect(result.sequences[0].steps).toStrictEqual(`B00:01:00 NOOP`);
   });
 
-  it('Quoted Parameters', async () => {
+  it('Quoted Parameters', () => {
     const satf = `
       $$EOH
       RT_on_board_block(/start.txt,\\start\\,
@@ -478,7 +480,7 @@ true UINT
         )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('start.txt');
     expect(result.sequences[0].inputParameters).toStrictEqual(`@INPUT_PARAMS_BEGIN
@@ -489,7 +491,7 @@ attitude_spec ENUM STORE_NAME "" "BOB_HARDWARE, SALLY_FARM, TIM_FLOWERS"
 @METADATA "INCLUSION_CONDITION" "param_rate == receive_rate"`);
   });
 
-  it('Verify Time types', async () => {
+  it('Verify Time types', () => {
     const satf = `
       $$EOH
       RT_on_board_block(/start.txt,\\start\\,
@@ -526,7 +528,7 @@ attitude_spec ENUM STORE_NAME "" "BOB_HARDWARE, SALLY_FARM, TIM_FLOWERS"
       )
       $$EOF
     `;
-    const result = await satfToSeqn(satf);
+    const result = satfToSeqn(satf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('start.txt');
     expect(result.sequences[0].inputParameters).toStrictEqual('');
@@ -543,20 +545,20 @@ C CMD`);
 
 //--- SASF To Seqn Test ----
 describe('sasfToSeqn', () => {
-  it('should return empty header and sequences for empty SATF string', async () => {
+  it('should return empty header and sequences for empty SATF string', () => {
     const sasf = '';
-    const result = await sasfToSeqn(sasf);
+    const result = sasfToSeqn(sasf);
     expect(result).toEqual({ metadata: '', sequences: [] } as ParsedSeqn);
   });
 
-  it('should return empty invalid SATF string', async () => {
+  it('should return empty invalid SATF string', () => {
     const sasf = ' invalid satf string ';
 
-    const result = await sasfToSeqn(sasf);
+    const result = sasfToSeqn(sasf);
     expect(result).toEqual({ metadata: '', sequences: [] } as ParsedSeqn);
   });
 
-  it('should parse valid SASF string with header and sequences', async () => {
+  it('should parse valid SASF string with header and sequences', () => {
     const sasf = `
       $$EOH
       CCS3ZF0000100000001NJPL3KS0L015$$MARK$$;
@@ -574,13 +576,13 @@ describe('sasfToSeqn', () => {
       $$EOD
       $$EOF
     `;
-    const result = await sasfToSeqn(sasf);
+    const result = sasfToSeqn(sasf);
     expect(result).toHaveProperty('metadata');
     expect(result).toHaveProperty('sequences');
     expect(result.sequences).toBeInstanceOf(Array);
   });
 
-  it('should return valid request with models', async () => {
+  it('should return valid request with models', () => {
     const sasf = `
       $$EOH
       $$EOD
@@ -603,7 +605,7 @@ describe('sasfToSeqn', () => {
         end;
       $$EOF
     `;
-    const result = await sasfToSeqn(sasf);
+    const result = sasfToSeqn(sasf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('VFT2_REQUEST_01');
     expect(result.sequences[0].requests).toStrictEqual(
@@ -618,7 +620,7 @@ describe('sasfToSeqn', () => {
     );
   });
 
-  it('should return valid G time type', async () => {
+  it('should return valid G time type', () => {
     const sasf = `
       $$EOH
       $$EOD
@@ -651,7 +653,7 @@ describe('sasfToSeqn', () => {
       end;
       $$EOF
     `;
-    const result = await sasfToSeqn(sasf);
+    const result = sasfToSeqn(sasf);
     expect(result).toHaveProperty('sequences');
     expect(result.sequences[0].name).toStrictEqual('name');
     expect(result.sequences[0].requests).toStrictEqual(
@@ -670,13 +672,13 @@ describe('sasfToSeqn', () => {
 
 //--- Seqn to SATF Test ----
 describe('seqnToSatf', () => {
-  it('should return empty header and empty SATF string', async () => {
-    const result = await seqnToSATF('');
+  it('should return empty header and empty SATF string', () => {
+    const result = seqnToSATF('');
     expect(result).toEqual({ header: {} } as ParsedSatf);
   });
 
-  it('should have headers and empty SATF string', async () => {
-    const result = await seqnToSATF(`
+  it('should have headers and empty SATF string', () => {
+    const result = seqnToSATF(`
 @METADATA "DATA_SET_ID" "SPACECRAFT_ACTIVITY_TYPE"
 @METADATA "MISSION_NAME" "BANANNA"
 @METADATA "SPACECRAFT_NAME" "BANANNA_BOT"
@@ -701,8 +703,8 @@ describe('seqnToSatf', () => {
     } as ParsedSatf);
   });
 
-  it('should return commented metadata', async () => {
-    const result = await seqnToSATF(
+  it('should return commented metadata', () => {
+    const result = seqnToSATF(
       `# username=rrgoetz
 # name=test.seq
 
@@ -715,8 +717,8 @@ C ECHO "HI"
     });
   });
 
-  it('should return variables', async () => {
-    const result = await seqnToSATF(`
+  it('should return variables', () => {
+    const result = seqnToSATF(`
     @LOCALS_BEGIN
     time UINT
     alpha STRING
@@ -762,8 +764,8 @@ end`,
     } as ParsedSatf);
   });
 
-  it('should return Parameters', async () => {
-    const result = await seqnToSATF(`
+  it('should return Parameters', () => {
+    const result = seqnToSATF(`
     @INPUT_PARAMS_BEGIN
     time UINT
     alpha STRING
@@ -805,8 +807,8 @@ end`,
     } as ParsedSatf);
   });
 
-  it('should return satf steps', async () => {
-    const result = await seqnToSATF(`
+  it('should return satf steps', () => {
+    const result = seqnToSATF(`
     R00:00:01.000 CMD true 1.45
     R00:00:01.000 CMD "OFF"
     R00:00:01.000 CMD .01`);
@@ -826,8 +828,8 @@ end`,
 end`);
   });
 
-  it('should return satf steps with comments', async () => {
-    const result = await seqnToSATF(`
+  it('should return satf steps with comments', () => {
+    const result = seqnToSATF(`
     R00:00:01.000 CMD true 1 #I am a description`);
     expect(result.steps).toEqual(`STEPS,
 	command(1,
@@ -838,8 +840,8 @@ end`);
 end`);
   });
 
-  it('should return satf steps with variables as args', async () => {
-    const result = await seqnToSATF(`
+  it('should return satf steps with variables as args', () => {
+    const result = seqnToSATF(`
     @INPUT_PARAMS_BEGIN
       temperature STRING
     @INPUT_PARAMS_END
@@ -858,8 +860,8 @@ end`);
 end`);
   });
 
-  it('should return satf steps with global as args and user_seq command', async () => {
-    const result = await seqnToSATF(
+  it('should return satf steps with global as args and user_seq command', () => {
+    const result = seqnToSATF(
       `
     @INPUT_PARAMS_BEGIN
       temperature STRING
@@ -884,8 +886,8 @@ end`);
 end`);
   });
 
-  it('should return supported metadata NTEXT', async () => {
-    const result = await seqnToSATF(`
+  it('should return supported metadata NTEXT', () => {
+    const result = seqnToSATF(`
     C NO_OP #NTEXT is supported "metadata"
     @METADATA "NTEXT" "this is a place for notes"`);
 
@@ -899,8 +901,8 @@ end`);
 end`);
   });
 
-  it('should return supported modeling time', async () => {
-    const result = await seqnToSATF(`
+  it('should return supported modeling time', () => {
+    const result = seqnToSATF(`
     C NO_OP #NTEXT is supported "metadata"
     @METADATA "NTEXT" "this is a place for notes"
     @MODEL "x" 1 "00:00:00"
@@ -919,40 +921,40 @@ end`);
 end`);
   });
 
-  it('Throw error for no time found', async () => {
+  it('Throw error for no time found', () => {
     try {
-      const result = await seqnToSATF(`
+      seqnToSATF(`
     CMD true 1.45`);
-    } catch (error) {
-      expect(error.message).toStrictEqual(
+    } catch (error: any) {
+      expect((error as Error).message).toStrictEqual(
         'No time found for command CMD true 1.45. Aborting Seqn -> SATF/SASF conversion...',
       );
     }
   });
 
-  it('Throw error for invalid time found', async () => {
+  it('Throw error for invalid time found', () => {
     try {
-      const result = await seqnToSATF(`
+      seqnToSATF(`
     R0:1:0 CMD true 1.45`);
-    } catch (error) {
-      expect(error.message).toStrictEqual(
+    } catch (error: any) {
+      expect((error as Error).message).toStrictEqual(
         'No time found for command R0:1:0 CMD true 1.45. Aborting Seqn -> SATF/SASF conversion...',
       );
     }
   });
 
-  it('Throw error for invalid time tag found', async () => {
+  it('Throw error for invalid time tag found', () => {
     try {
-      const result = await seqnToSATF(`
+      seqnToSATF(`
     Z00:00:00 CMD true 1.45`);
-    } catch (error) {
-      expect(error.message).toStrictEqual(
+    } catch (error: any) {
+      expect((error as Error).message).toStrictEqual(
         'No time found for command Z00:00:00 CMD true 1.45. Aborting Seqn -> SATF/SASF conversion...',
       );
     }
   });
 
-  it('should round trip a satf', async () => {
+  it('should round trip a satf', () => {
     const satf = `
   $$EOH
 
@@ -985,8 +987,8 @@ end`);
       end,
   )
   $$EOF`;
-    const seqn = await satfToSeqn(satf);
-    const result = await seqnToSATF(`${seqn.sequences[0].inputParameters}\n${seqn.sequences[0].steps}`);
+    const seqn = satfToSeqn(satf);
+    const result = seqnToSATF(`${seqn.sequences[0].inputParameters}\n${seqn.sequences[0].steps}`);
     expect(result.parameters?.trimEnd()).toEqual(
       `PARAMETERS,
 	status(
@@ -1016,8 +1018,8 @@ end`,
 end`,
     );
   });
-  it('should return valid satf times', async () => {
-    const result = await seqnToSATF(`
+  it('should return valid satf times', () => {
+    const result = seqnToSATF(`
     A2025-001T10:00:00 CMD
     R10:00:00 CMD
     R500 CMD
@@ -1060,8 +1062,8 @@ end`);
 
 //--- Seqn to SASF Test
 describe('seqnToSasf', () => {
-  it('Should return a barebone sasf', async () => {
-    const result = await seqnToSASF(`
+  it('Should return a barebone sasf', () => {
+    const result = seqnToSASF(`
     C @REQUEST_BEGIN("request1")
     @REQUEST_END
     @METADATA "REQUESTOR" "me"
@@ -1079,8 +1081,8 @@ end;`,
     );
   });
 
-  it('Should round trip an sasf', async () => {
-    const seqN = await sasfToSeqn(
+  it('Should round trip an sasf', () => {
+    const seqN = sasfToSeqn(
       `CCSD3ZF0000100000001NJPL3KS0L015$$MARK$$;
       DATA_SET_ID = SPACECRAFT_ACTIVITY_SEQUENCE;
       CCSD3RE00000$$MARK$$NJPL3IF0M00500000001;
@@ -1088,7 +1090,7 @@ end;`,
       $$EOD
 
       # I am a comment inside a sasf
-      
+
       request(ep_atr_testing_setup,
           REQUESTOR, "me",
           PROCESSOR, "VC2AB",
@@ -1108,7 +1110,7 @@ end;`,
               ),
       end;`,
     );
-    const result = await seqnToSASF(seqN.sequences[0].requests!);
+    const result = seqnToSASF(seqN.sequences[0].requests!);
     expect(result.requests?.trimEnd()).toEqual(
       `request(ep_atr_testing_setup,
 	START_TIME, 2024-001T00:00:00.000,ABSOLUTE,
@@ -1130,8 +1132,8 @@ end;`,
 end;`,
     );
   });
-  it('should return valid satf times', async () => {
-    const result = await seqnToSASF(`
+  it('should return valid satf times', () => {
+    const result = seqnToSASF(`
       G-00:00:00.100 "test" @REQUEST_BEGIN("request.name")
         A2025-001T10:00:00 CMD
         R10:00:00 CMD

--- a/src/converters/satf-sasf-utils.ts
+++ b/src/converters/satf-sasf-utils.ts
@@ -1,13 +1,7 @@
 import type { SyntaxNode } from '@lezer/common';
 import { Tree } from '@lezer/common';
 import type { CommandDictionary, FswCommandArgument } from '@nasa-jpl/aerie-ampcs';
-import {
-  getBalancedDuration,
-  getDurationTimeComponents,
-  parseDurationString,
-  validateTime,
-  TimeTypes,
-} from '@nasa-jpl/aerie-time-utils';
+import { getBalancedDuration, parseDurationString, validateTime, TimeTypes } from '@nasa-jpl/aerie-time-utils';
 import { SatfSasfParser } from '../languages/satf/grammar/satf-sasf.js';
 import {
   quoteEscape,
@@ -22,23 +16,22 @@ import { seqnParser } from '../languages/seq-n/seq-n.js';
 import { SEQN_NODES } from '../languages/seq-n/seqn-grammar-constants.js';
 import { parseVariables } from './seqnToSeqJson.js';
 /**
- * Asynchronously converts a parsed SeqN tree via lezer into a structured SATF representation.
+ * Converts a parsed SeqN tree via lezer into a structured SATF representation.
  *
  * Parse different sections (metadata, variables, steps) of the SeqN tree and
  * assemble them into a `ParsedSatf` object containing the corresponding SATF sections.
  *
- * @async
  * @param {string} sequence - The original SeqN source text corresponding to the `seqnTree`.
  * @param {string[]} [globalVariables] - Optional. A list of predefined global variable names to be used
  * @param {CommandDictionary} [commandDictionary] - Optional. A dictionary containing command definitions.
- * @returns {Promise<ParsedSatf>} A Promise that resolves to an object containing the generated
- * SATF `header`, `parameters , `variables`, and `steps` block strings (or undefined if a section is empty/not generated).
+ * @returns {ParsedSatf} An object containing the generated SATF `header`, `parameters , `variables`,
+ * and `steps` block strings (or undefined if a section is empty/not generated).
  */
-export async function seqnToSATF(
+export function seqnToSATF(
   seqn: string,
   globalVariables?: string[],
   commandDictionary?: CommandDictionary,
-): Promise<ParsedSatf> {
+): ParsedSatf {
   const seqnTree = seqnParser.parse(seqn);
   const header = parseHeaderfromSeqn(seqnTree, seqn);
   const parameters = satfVariablesFromSeqn(seqnTree, seqn);
@@ -59,24 +52,19 @@ export async function seqnToSATF(
 }
 
 /**
- * Asynchronously converts a parsed SeqN tree via lezer into a structured SASF representation.
+ * Converts a parsed SeqN tree via lezer into a structured SASF representation.
  *
  * Parse the metadata section and generate SASF request blocks from the SeqN tree.
  * It then combines these into a `ParsedSasf` object.
  *
- * @async
  * @param {string} sequence - The original SeqN source text corresponding to the `seqnTree`.
  * @param {string[]} [globalVariables] - Optional. A list of predefined global variable names to be used
  *
  * @param {CommandDictionary} [commandDictionary] - Optional. A dictionary containing command definitions,
- * @returns {Promise<ParsedSasf>} A Promise that resolves to an object containing the generated
- * SASF `metadata` string and the concatenated `requests` string (or undefined if a section is empty/not generated).
+ * @returns {ParseSasf} An object containing the generated SASF `metadata` string
+ * and the concatenated `requests` string (or undefined if a section is empty/not generated).
  */
-export async function seqnToSASF(
-  seqn: string,
-  globalVariables?: string[],
-  commandDictionary?: CommandDictionary,
-): Promise<ParseSasf> {
+export function seqnToSASF(seqn: string, globalVariables?: string[], commandDictionary?: CommandDictionary): ParseSasf {
   const seqnTree = seqnParser.parse(seqn);
   const header = parseHeaderfromSeqn(seqnTree, seqn);
 
@@ -433,10 +421,10 @@ function serializeSeqNArgs(args: any[]): string {
 }
 
 function getSatfVariableNames(seqnTree: Tree, text: string): string[] {
-  let types = [SEQN_NODES.PARAMETER_DECLARATION, SEQN_NODES.LOCAL_DECLARATION];
-  let names: string[] = [];
+  const types = [SEQN_NODES.PARAMETER_DECLARATION, SEQN_NODES.LOCAL_DECLARATION];
+  const names: string[] = [];
   for (let i = 0; i < types.length; i++) {
-    let variableContainer = seqnTree.topNode.getChild(types[i]);
+    const variableContainer = seqnTree.topNode.getChild(types[i]);
     if (!variableContainer) {
       continue;
     }
@@ -510,13 +498,19 @@ function satfVariablesFromSeqn(
   const serializedVariables = variables?.map(variable => {
     const tags = [];
     tags.push(`\tTYPE,${variable.type}`);
-    if (variable.enum_name) tags.push(`\tENUM_NAME,\\${variable.enum_name}\\`);
+    if (variable.enum_name) {
+      tags.push(`\tENUM_NAME,\\${variable.enum_name}\\`);
+    }
     variable.allowable_ranges &&
       variable.allowable_ranges.forEach(range => {
         tags.push(`\tRANGE,\\${range.min}...${range.max}\\`);
       });
-    if (variable.allowable_values) tags.push(`\tRANGE,\\${variable.allowable_values}\\`);
-    if (variable.sc_name) tags.push(`\tSC_NAME,\\${variable.sc_name}\\`);
+    if (variable.allowable_values) {
+      tags.push(`\tRANGE,\\${variable.allowable_values}\\`);
+    }
+    if (variable.sc_name) {
+      tags.push(`\tSC_NAME,\\${variable.sc_name}\\`);
+    }
     return `${variable.name}(\n` + tags.join(',\n') + `\n)`;
   });
 
@@ -544,9 +538,9 @@ function sasfRequestFromSeqN(
       const request =
         `request(${name},` +
         `\n\tSTART_TIME, ${parsedTime.tag},${parsedTime.type}` +
-        `${requester ? `,\n\t${requester.replaceAll('\\', '\"')}` : ''}` +
-        `${processor ? `,\n\t${processor.replaceAll('\\', '\"')}` : ''}` +
-        `${key ? `,\n\t${key.replaceAll('\\', '\"')}` : ''})`;
+        `${requester ? `,\n\t${requester.replaceAll('\\', '"')}` : ''}` +
+        `${processor ? `,\n\t${processor.replaceAll('\\', '"')}` : ''}` +
+        `${key ? `,\n\t${key.replaceAll('\\', '"')}` : ''})`;
       `\n\n`;
       let order = 1;
       let child = requestNode?.getChild(SEQN_NODES.STEPS)?.firstChild;
@@ -565,18 +559,16 @@ function sasfRequestFromSeqN(
 }
 
 /**
- * Parses a SATF formatted string asynchronously to extract header information and sequence data.
+ * Parses a SATF formatted string to extract header information and sequence data.
  * It utilizes the SatfSasfParser to generate SeqN parts.
  *
- * @async
  * @function satfToSeqn
  * @param {string} satf - The SATF formatted string content to parse.
- * @returns {Promise<ParsedSeqn>} A Promise that resolves to an object containing the parsed header
- * and an array of sequence objects.
+ * @returns {ParsedSeqn} An object containing the parsed header and an array of sequence objects.
  * If the input string does not contain a top-level SATF structure recognized by the parser,
- * it resolves with a default empty ParsedSequence object (e.g., { header: "", sequences: [] }).
+ * it returns a default empty ParsedSequence object (e.g., { header: "", sequences: [] }).
  */
-export async function satfToSeqn(satf: string): Promise<ParsedSeqn> {
+export function satfToSeqn(satf: string): ParsedSeqn {
   const base = SatfSasfParser.parse(satf).topNode;
 
   const satfNode = base.getChild(SATF_SASF_NODES.SATF);
@@ -591,18 +583,16 @@ export async function satfToSeqn(satf: string): Promise<ParsedSeqn> {
 }
 
 /**
- * Parses a SASF formatted string asynchronously to extract header information and sequence data.
+ * Parses a SASF formatted string to extract header information and sequence data.
  * It utilizes the SatfSasfParser to generate SeqN parts.
  *
- * @async
  * @function sasfToSeqn
  * @param {string} satf - The SASF formatted string content to parse.
- * @returns {Promise<ParsedSeqn>} A Promise that resolves to an object containing the parsed header
- * and an array of sequence objects.
+ * @returns {ParsedSeqn} An object containing the parsed header and an array of sequence objects.
  * If the input string does not contain a top-level SASF structure recognized by the parser,
- * it resolves with a default empty ParsedSequence object (e.g., { header: "", sequences: [] }).
+ * it returns a default empty ParsedSequence object (e.g., { header: "", sequences: [] }).
  */
-export async function sasfToSeqn(sasf: string): Promise<ParsedSeqn> {
+export function sasfToSeqn(sasf: string): ParsedSeqn {
   const base = SatfSasfParser.parse(sasf).topNode;
 
   const sasfNode = base.getChild(SATF_SASF_NODES.SASF);
@@ -739,21 +729,6 @@ function parseBody(bodyNode: SyntaxNode | null, text: string): Seqn[] {
   }
 
   return [];
-}
-
-function parseVariableName(parameterNode: SyntaxNode | null, text: string): string[] {
-  if (!parameterNode) {
-    return [];
-  }
-  const entries = parameterNode.getChildren(SATF_SASF_NODES.ENTRY);
-  if (!entries || entries.length == 0) {
-    return [];
-  }
-
-  return entries.map(param => {
-    const nameNode = param.getChild(SATF_SASF_NODES.NAME);
-    return nameNode ? `${text.slice(nameNode.from, nameNode.to)}` : '';
-  });
 }
 
 /** Mapping between SATF and SeqN from Taifun
@@ -913,7 +888,7 @@ function parseTimeTagNode(timeValueNode: SyntaxNode | null, timeTagNode: SyntaxN
 }
 
 function parseComment(commentNode: SyntaxNode | null, text: string): string {
-  let comment = commentNode
+  const comment = commentNode
     ? `${text
         .slice(commentNode.from, commentNode.to)
         .split('\n')
@@ -1044,7 +1019,7 @@ function parseModel(modelNode: SyntaxNode | null, text: string): string {
   // 4. Mis-matched number of models/durations not covered by cases 1 or 2 -> throw error
 
   if (
-    modelsNode.length != durationNodes.length &&
+    modelsNode.length !== durationNodes.length &&
     ((modelsNode.length > 2 && durationNodes.length > 1) || modelsNode.length < durationNodes.length)
   ) {
     throw new Error(`Mismatch of models to durations`);
@@ -1055,7 +1030,7 @@ function parseModel(modelNode: SyntaxNode | null, text: string): string {
     .map((model, idx) => {
       const keyNode = model.getChild(SATF_SASF_NODES.KEY);
       const valueNode = model.getChild(SATF_SASF_NODES.VALUE);
-      if (modelsNode.length != 0 && durationNodes.length == 1) {
+      if (modelsNode.length !== 0 && durationNodes.length === 1) {
         durationTime = text.slice(durationNodes[0].from, durationNodes[0].to);
       } else if (modelsNode.length === durationNodes.length) {
         durationTime = text.slice(durationNodes[idx].from, durationNodes[idx].to);

--- a/src/converters/seqJsonToSeqn.test.ts
+++ b/src/converters/seqJsonToSeqn.test.ts
@@ -2,8 +2,8 @@ import type { SeqJson } from '@nasa-jpl/seq-json-schema/types';
 import { seqJsonToSeqn } from './seqJsonToSeqn.js';
 import { describe, expect, it } from 'vitest';
 
-describe('from-seq-json.ts', async () => {
-  it('converts a seq json id and metadata to sequence', async () => {
+describe('from-seq-json.ts', () => {
+  it('converts a seq json id and metadata to sequence', () => {
     const seqJson: SeqJson = {
       id: 'test',
       metadata: {
@@ -21,7 +21,7 @@ describe('from-seq-json.ts', async () => {
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('Symbols should not be quoted', async () => {
+  it('Symbols should not be quoted', () => {
     const seqJson: SeqJson = {
       id: 'testSymbol',
       locals: [
@@ -93,7 +93,7 @@ C DDM_BANANA L00INT L01INT
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json LGO to sequence', async () => {
+  it('converts a seq json LGO to sequence', () => {
     const seqJson: SeqJson = {
       id: 'test',
       metadata: {
@@ -125,7 +125,7 @@ C FSW_CMD_3
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json variables to sequence', async () => {
+  it('converts a seq json variables to sequence', () => {
     const seqJson: SeqJson = {
       id: 'testVariable',
 
@@ -197,7 +197,7 @@ L01ENUM ENUM
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json file to a correct sequence', async () => {
+  it('converts a seq json file to a correct sequence', () => {
     const seqJson: SeqJson = {
       id: '42',
       metadata: {},
@@ -308,7 +308,7 @@ C FSW_CMD_3
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json command model and metadata to sequence', async () => {
+  it('converts a seq json command model and metadata to sequence', () => {
     const seqJson: SeqJson = {
       id: 'testCommandModeling',
       metadata: {
@@ -371,7 +371,7 @@ C ECHO "test"
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json description to sequence', async () => {
+  it('converts a seq json description to sequence', () => {
     const seqJson: SeqJson = {
       id: 'testDescription',
       metadata: {},
@@ -448,7 +448,7 @@ C FSW_CMD_2 10 "ENUM" # fsw cmd 2 description
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json immediate commands to sequence', async () => {
+  it('converts a seq json immediate commands to sequence', () => {
     const seqJson: SeqJson = {
       id: 'testImmediate',
       immediate_commands: [
@@ -512,7 +512,7 @@ NOOP # noop command, no arguments
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json hardware commands to sequence', async () => {
+  it('converts a seq json hardware commands to sequence', () => {
     const seqJson: SeqJson = {
       hardware_commands: [
         {
@@ -547,7 +547,7 @@ HWC3
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('converts a seq json time tags to sequence', async () => {
+  it('converts a seq json time tags to sequence', () => {
     const seqJson: SeqJson = {
       id: 'testTime',
       metadata: {},
@@ -595,7 +595,7 @@ E-00:00:01.000 FSE_CMD 10 "ENUM"
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('should convert activate', async () => {
+  it('should convert activate', () => {
     const seqJson: SeqJson = {
       id: 'id',
       metadata: {},
@@ -626,7 +626,7 @@ A2024-123T12:34:56 @ACTIVATE("activate.name") # No Args
     expect(sequence.trim()).toEqual(expectedSequence.trim());
   });
 
-  it('should convert load', async () => {
+  it('should convert load', () => {
     const seqJson: SeqJson = {
       id: 'id',
       metadata: {},
@@ -656,7 +656,7 @@ A2024-123T12:34:56 @LOAD("load.name")
     expect(sequence.trim()).toEqual(expectedSequence.trim());
   });
 
-  it('should convert ground event', async () => {
+  it('should convert ground event', () => {
     const seqJson: SeqJson = {
       id: 'id',
       metadata: {},
@@ -700,7 +700,7 @@ R123T11:55:33 @GROUND_EVENT("ground_event.name") "foo" 1 2 3
     expect(sequence.trim()).toEqual(expectedSequence.trim());
   });
 
-  it('converts a seq json empty repeat args to sequence', async () => {
+  it('converts a seq json empty repeat args to sequence', () => {
     const seqJson: SeqJson = {
       id: 'testRepeat',
       metadata: {},
@@ -760,7 +760,7 @@ C FSA_CMD 10 [] "USA" ["96707-898" "92604-623"]
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('should convert requests to seq format', async () => {
+  it('should convert requests to seq format', () => {
     const seqJson: SeqJson = {
       id: 'id',
       metadata: {},
@@ -834,7 +834,7 @@ C FSA_CMD 10 [] "USA" ["96707-898" "92604-623"]
     expect(normalizeWhitespace(sequence)).toEqual(normalizeWhitespace(expectedSequence));
   });
 
-  it('converts a quoted string', async () => {
+  it('converts a quoted string', () => {
     const seqJson: SeqJson = {
       id: 'escaped_quotes',
       metadata: {},
@@ -879,7 +879,7 @@ C ECHO2 "\\"Can\\" this handle leading and trailing Escaped\\" quotes??\\"" # "C
     expect(sequence).toEqual(expectedSequence);
   });
 
-  it('BooleanArguments to sequence', async () => {
+  it('BooleanArguments to sequence', () => {
     const seqJson: SeqJson = {
       id: 'test',
       metadata: {},

--- a/src/converters/seqnToSeqJson.test.ts
+++ b/src/converters/seqnToSeqJson.test.ts
@@ -69,8 +69,8 @@ const commandDictionary: CommandDictionary = {
 
 const commandBanana = parse(readFileSync('tests/dictionary/command_banananation.xml', 'utf-8'));
 
-describe('convert a sequence to seq json', async () => {
-  it('hardware command', async () => {
+describe('convert a sequence to seq json', () => {
+  it('hardware command', () => {
     const seq = `@HARDWARE
 HDW_CMD`;
     const id = 'test';
@@ -87,7 +87,7 @@ HDW_CMD`;
     expect(actual).toEqual(expectedJson);
   });
 
-  it('immediate command', async () => {
+  it('immediate command', () => {
     const seq = `@IMMEDIATE
 ECHO "hello"
 # activate sequences
@@ -130,7 +130,7 @@ ECHO "hello"
     expect(actual).toEqual(expectedJson);
   });
 
-  it('multiple hardware commands', async () => {
+  it('multiple hardware commands', () => {
     const seq = `@HARDWARE
 HDW_CMD_1
 # comment
@@ -153,7 +153,7 @@ HDW_CMD_2
     expect(actual).toEqual(expectedJson);
   });
 
-  it('load and go with commands', async () => {
+  it('load and go with commands', () => {
     const seq = `@LOAD_AND_GO
 C FSW_CMD_1 1e3 2.34
 # comment
@@ -211,7 +211,7 @@ C FSW_CMD_1 0.123 -2.34 # inline description
     expect(actual).toEqual(expectedJson);
   });
 
-  it('command dictionary file', async () => {
+  it('command dictionary file', () => {
     const id = 'test.sequence';
     const seq = `
 @ID "test.inline"
@@ -276,7 +276,7 @@ R71 ECHO    L02STR
     expect(actual).toEqual(expectedJson);
   });
 
-  it('repeat args', async () => {
+  it('repeat args', () => {
     const id = 'test.sequence';
     const seq = `@ID "test.inline"
 
@@ -338,7 +338,7 @@ R10 PACKAGE_BANANA     2      [    "bundle1"    5 "bundle2" 10]
     expect(actual).toEqual(expectedJson);
   });
 
-  it('local variables', async () => {
+  it('local variables', () => {
     const id = 'test.sequence';
     const seq = `@ID "test.inline"
 @LOCALS L00STR
@@ -404,7 +404,7 @@ C ECHO L01STR
     expect(actual).toEqual(expectedJson);
   });
 
-  it('local and parameter block', async () => {
+  it('local and parameter block', () => {
     const id = 'test.sequence';
     const seq = `@ID "test.inline"
 @LOCALS_BEGIN
@@ -512,7 +512,7 @@ C ECHO SIZE
     expect(actual).toEqual(expectedJson);
   });
 
-  it('header ordering', async () => {
+  it('header ordering', () => {
     function allPermutations(inputArr: string[]) {
       const result: string[][] = [];
       function permute(arr: string[], m: string[] = []) {
@@ -575,7 +575,7 @@ C ECHO SIZE
     }
   });
 
-  it('Convert quoted strings', async () => {
+  it('Convert quoted strings', () => {
     const seq = `@ID "escaped_quotes"
 
     R1 ECHO "Can this handle \\"Escaped\\" quotes??" # and this "too"`;
@@ -606,7 +606,7 @@ C ECHO SIZE
     expect(actual).toEqual(JSON.parse(expected));
   });
 
-  it('Convert quoted metadata and models', async () => {
+  it('Convert quoted metadata and models', () => {
     const seq = `@ID "escaped_metadata"
 
 R00:00:01 ECHO "Can this handle \\"Escaped\\" quotes??" # and this "too"
@@ -678,7 +678,7 @@ R00:00:01 ECHO "Can this handle \\"Escaped\\" quotes??" # and this "too"
     expect(actual).toEqual(JSON.parse(expected));
   });
 
-  it('should generate loads, activates, ground blocks', async () => {
+  it('should generate loads, activates, ground blocks', () => {
     const id = 'test.sequence';
     const seq = `@ID "${id}"
 A2024-123T12:34:56 @ACTIVATE("activate.name") # No Args
@@ -820,7 +820,7 @@ R123T12:34:56 @ACTIVATE("act2.name") "foo" 1 2 3  # Comment text
     expect(actual).toEqual(expectedJson);
   });
 
-  it('should serialize a request with nested metadata', async () => {
+  it('should serialize a request with nested metadata', () => {
     const input = `
 A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
   C CMD_0 1 2 3
@@ -898,7 +898,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
     expect(actual).toEqual(expected);
   });
 
-  it('should serialize a request with simple metadata', async () => {
+  it('should serialize a request with simple metadata', () => {
     const input = `
 G+03:00:00 "GroundEpochName" @REQUEST_BEGIN("request2.name")
   C CMD_0 1 2 3
@@ -973,7 +973,7 @@ G+03:00:00 "GroundEpochName" @REQUEST_BEGIN("request2.name")
     expect(actual).toEqual(expected);
   });
 
-  it('should serialize multiple requests', async () => {
+  it('should serialize multiple requests', () => {
     const input = `
 A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
   C CMD_0 1 2 3
@@ -1115,7 +1115,7 @@ G03:00:00 "GroundEpochName" @REQUEST_BEGIN("request2.name")
     expect(actual).toEqual(expected);
   });
 
-  it('should handle all time tag types', async () => {
+  it('should handle all time tag types', () => {
     const seq = `A2029-365T23:20:50 BAKE_BREAD
 A2029-365T23:21:51.123 BAKE_BREAD
 R00:00:30 BAKE_BREAD
@@ -1208,7 +1208,7 @@ E-00:06:40.333 BAKE_BREAD`;
   });
 
   describe('round trip', () => {
-    it('should round trip commands', async () => {
+    it('should round trip commands', () => {
       const input = `
   @ID "test.seq"
   C FSW_CMD_1 1e3 2.34
@@ -1221,7 +1221,7 @@ E-00:06:40.333 BAKE_BREAD`;
       expect(seqJson1).toEqual(seqJson2);
     });
 
-    it('should round trip activates, loads, etc', async () => {
+    it('should round trip activates, loads, etc', () => {
       const input = `
 @ID "test.seq"
 C FSW_CMD_1 1e3 2.34
@@ -1253,7 +1253,7 @@ G+3 "GroundEpochName" @REQUEST_BEGIN("request2.name")
   });
 
   describe('control character escaping', () => {
-    it('should handle control characters in @ID', async () => {
+    it('should handle control characters in @ID', () => {
       // Test with a tab character (0x09) embedded in the ID string
       const seq = `
       @ID "id_with\x09tab"
@@ -1262,7 +1262,7 @@ G+3 "GroundEpochName" @REQUEST_BEGIN("request2.name")
       expect(actual.id).toBe('id_with\ttab');
     });
 
-    it('should handle control characters in string arguments', async () => {
+    it('should handle control characters in string arguments', () => {
       // Test with various control characters in a string argument
       const seq = `
       @ID "control_chars_test"
@@ -1282,7 +1282,7 @@ G+3 "GroundEpochName" @REQUEST_BEGIN("request2.name")
       });
     });
 
-    it('should handle null and other low control characters', async () => {
+    it('should handle null and other low control characters', () => {
       // Test with null (0x00) and bell (0x07) characters
       const seq = `
       @ID "test"
@@ -1301,7 +1301,7 @@ G+3 "GroundEpochName" @REQUEST_BEGIN("request2.name")
   });
 });
 
-it('should serialize a boolean arg', async () => {
+it('should serialize a boolean arg', () => {
   const input = `
 
 C CMD_0 true false [ false true ]

--- a/src/languages/seq-n/language.test.ts
+++ b/src/languages/seq-n/language.test.ts
@@ -1,14 +1,11 @@
-import {describe, expect, it, test} from 'vitest';
-import {sanitizeSmartQuotes} from "./language";
-import {satfToSeqn} from "../../converters/satf-sasf-utils";
+import { describe, expect, it } from 'vitest';
+import { sanitizeSmartQuotes } from './language';
 
 describe('sanitizeSmartQuotes', () => {
-  it('should replace curly quotes with ASCII quotes & leave all other text alone', async () => {
+  it('should replace curly quotes with ASCII quotes & leave all other text alone', () => {
     const unchanged = 'hello';
     const withQuotes = 'this has “curly double quotes” and ‘curly single quotes’';
     expect(sanitizeSmartQuotes(unchanged)).toEqual(unchanged);
-    expect(sanitizeSmartQuotes(withQuotes)).toEqual(
-      'this has "curly double quotes" and \'curly single quotes\''
-    );
+    expect(sanitizeSmartQuotes(withQuotes)).toEqual('this has "curly double quotes" and \'curly single quotes\'');
   });
 });

--- a/src/languages/vml/cdl-dictionary.test.ts
+++ b/src/languages/vml/cdl-dictionary.test.ts
@@ -138,7 +138,7 @@ END STEM
 
 `;
 
-describe('cdl parse tests', async () => {
+describe('cdl parse tests', () => {
   test('inline definition', () => {
     const cdlDictionary = parseCdlDictionary(cdlString);
     expect(cdlDictionary.header.mission_name).toBe('Unit_test');


### PR DESCRIPTION
This removes the `async` from the SASF/SATF conversion functions since the actual implementations doesn't return promises and it doesn't match up with the synchronous interface of `PhoenixAdaptation`. 

It might be a good idea to fully update the interface to be able to take asynchronous adaptations, but maybe at a later point in time.